### PR TITLE
add issue template which tells user to raise issue for assertj at htt…

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+This repository contains the AssertJ website. 
+
+Please use https://github.com/joel-costigliola/assertj-core/issues to create issues for AssertJ itself.


### PR DESCRIPTION
…ps://github.com/joel-costigliola/assertj-core/issues

During the last days more issues for assertj-core were created here than at the correct location.

@joel-costigliola Maybe you should consider renaming this repository to assertj-website or something similar (if possible).
