### PR TITLE
remove "We are trying to make AssertJ 2.x Android compatible but this…

### DIFF
--- a/assertj-core.html
+++ b/assertj-core.html
@@ -98,7 +98,6 @@
                <li>AssertJ 3.x requires Java 8 or higher (not suitable for Android due to <span class="small-code">Path</span> assertions)</li>
             </ul>
             <p>Note that AssertJ 3.x includes all AssertJ 2.x features and adds Java 8 specific ones (like <a href="assertj-core-features-highlight.html#exception-assertion">exception assertions with lambdas</a>).</p>
-            <p>We are trying to make AssertJ 2.x Android compatible but this is not yet achieved.</p>
          </p>
 
          <p>AssertJ core <a href="https://github.com/joel-costigliola/assertj-core">code</a> and

--- a/templates/assertj-core-template.html
+++ b/templates/assertj-core-template.html
@@ -25,7 +25,6 @@ $menu
                <li>AssertJ 3.x requires Java 8 or higher (not suitable for Android due to <span class="small-code">Path</span> assertions)</li>
             </ul>
             <p>Note that AssertJ 3.x includes all AssertJ 2.x features and adds Java 8 specific ones (like <a href="assertj-core-features-highlight.html#exception-assertion">exception assertions with lambdas</a>).</p>
-            <p>We are trying to make AssertJ 2.x Android compatible but this is not yet achieved.</p>
          </p>
 
          <p>AssertJ core <a href="https://github.com/joel-costigliola/assertj-core">code</a> and


### PR DESCRIPTION
… is not yet achieved." warning

I think after 2.5 this can be removed.

What do you think?
