### PR TITLE
remove migration from FEST Assert and conversion of JUnit Assertions …

### DIFF
--- a/assertj-core.html
+++ b/assertj-core.html
@@ -111,14 +111,8 @@
          </p>
 
          <p>Convert existing JUnit assertions to AssertJ ones : we have a <a href="assertj-core-converting-junit-assertions-to-assertj.html">guide</a> to easily
-            convert JUnit assertions to AssertJ. We plan to write a maven plugin to automate this task.
+            convert JUnit assertions to AssertJ.
          </p>
-
-         <p>Migrating from Fest Asset ? Check our migration guide and do not worry, migration is simple:</p>
-         <ul>
-            <li><a href="assertj-core-migrating-from-fest.html">Migrating from Fest 2.x</a></li>
-            <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">Migrating from Fest 1.4</a></li>
-         </ul>
 
          <p>If you have any questions, please use the
             <a href="https://groups.google.com/forum/?fromgroups=#!forum/assertj">AssertJ google group</a>.</p>

--- a/templates/assertj-core-template.html
+++ b/templates/assertj-core-template.html
@@ -38,14 +38,8 @@ $menu
          </p>
 
          <p>Convert existing JUnit assertions to AssertJ ones : we have a <a href="assertj-core-converting-junit-assertions-to-assertj.html">guide</a> to easily
-            convert JUnit assertions to AssertJ. We plan to write a maven plugin to automate this task.
+            convert JUnit assertions to AssertJ.
          </p>
-
-         <p>Migrating from Fest Asset ? Check our migration guide and do not worry, migration is simple:</p>
-         <ul>
-            <li><a href="assertj-core-migrating-from-fest.html">Migrating from Fest 2.x</a></li>
-            <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">Migrating from Fest 1.4</a></li>
-         </ul>
 
          <p>If you have any questions, please use the
             <a href="https://groups.google.com/forum/?fromgroups=#!forum/assertj">AssertJ google group</a>.</p>


### PR DESCRIPTION
…from quickstart

I believe migration from FEST Assert is not a common scenario anymore.

I think conversion of JUnit Asertions is more of an advanced topic. It's helpful for somebody who is already convinced of the advantages of AssertJ, not for somebody looking into AssertJ for the first time.

What do you think?
