### PR TITLE
Change release date of 3.5.2

### DIFF
--- a/assertj-core-news.html
+++ b/assertj-core-news.html
@@ -116,7 +116,7 @@
 
 <h3 class="page-header"><span id="assertj-core-3.5.2"></span>AssertJ Core 3.5.2 bugfix release</h3>
 
-   <p>Release date : 2016-08-17<br>
+   <p>Release date : 2016-07-17<br>
 
    <p>Thanks to <span class="contributor">Cristiano Gavião</span> for the fix.</p>
 

--- a/assertj-db-concepts.html
+++ b/assertj-db-concepts.html
@@ -1911,7 +1911,7 @@ output(table).withType(OutputType.HTML).....;</code></pre>
       <li>a stream (with the <a href="db/current/api/org/assertj/db/output/AbstractOutputter.html#toStream-java.io.OutputStream-">toStream(OutputStream outputStream)</a> method)
       </li>
       </ul>
-      <p>Note that with the last method the possible number of destinations is very big.</p>
+      <p>Note that with this last method the possibilities of destination are really flexible.</p>
       <p>These three methods are fluent. In this short example, the output is a plain text representation in the console and a html output in a file :</p> 
       <pre><code class="java">// Display the content of the table with plain text in the console 
 // and with HTML output in the file

--- a/assertj-news.html
+++ b/assertj-news.html
@@ -77,7 +77,7 @@
          This page summarizes what happened recently in AssertJ projects and the current work.
 
          <h4 class="page-header">AssertJ Core 3.5.2 bugfix release</h4>
-         <p>Release date : 2016-08-17</p>
+         <p>Release date : 2016-07-17</p>
          <p>See what's <a href="assertj-core-news.html#assertj-core-3.5.2">new and noteworthy</a></p>
 
          <h4 class="page-header">AssertJ Swing 3.4.0 release</h4>

--- a/templates/assertj-core-news-template.html
+++ b/templates/assertj-core-news-template.html
@@ -43,7 +43,7 @@ $menu
 
 <h3 class="page-header"><span id="assertj-core-3.5.2"></span>AssertJ Core 3.5.2 bugfix release</h3>
 
-   <p>Release date : 2016-08-17<br>
+   <p>Release date : 2016-07-17<br>
 
    <p>Thanks to <span class="contributor">Cristiano Gavião</span> for the fix.</p>
 

--- a/templates/assertj-news-template.html
+++ b/templates/assertj-news-template.html
@@ -17,7 +17,7 @@ $menu
          This page summarizes what happened recently in AssertJ projects and the current work.
 
          <h4 class="page-header">AssertJ Core 3.5.2 bugfix release</h4>
-         <p>Release date : 2016-08-17</p>
+         <p>Release date : 2016-07-17</p>
          <p>See what's <a href="assertj-core-news.html#assertj-core-3.5.2">new and noteworthy</a></p>
 
          <h4 class="page-header">AssertJ Swing 3.4.0 release</h4>


### PR DESCRIPTION
I noticed that 3.5.2 was listed as being in the future at the time of reading, so have moved it back a month to July (when it was actually released), and regenerated the site (This caused a minor wording change in `assertj-db-concepts.html` to be reverted: 5c04e77cc77550d5f37ca7c63e048c5bc0eb0c71 had [a change committed to the output file](https://github.com/eddarmitage/assertj/commit/5c04e77cc77550d5f37ca7c63e048c5bc0eb0c71#diff-a35a26c373ca67f0db4a8b2b185b2dacR1914) that wasn't in [the template file](https://github.com/joel-costigliola/assertj/commit/5c04e77cc77550d5f37ca7c63e048c5bc0eb0c71#diff-4d5bea3c3c3387593ff1643e2b00e8d1L1852) - I'm not sure if this was intentional or not.)
