### PR TITLE
Fix #59 ""Converting TestNG Assertions to AssertJ" section no longer …

### DIFF
--- a/assertj-core-conditions.html
+++ b/assertj-core-conditions.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core-converting-junit-assertions-to-assertj.html
+++ b/assertj-core-converting-junit-assertions-to-assertj.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core-converting-testng-assertions-to-assertj.html
+++ b/assertj-core-converting-testng-assertions-to-assertj.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core-custom-assertions.html
+++ b/assertj-core-custom-assertions.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core-features-highlight.html
+++ b/assertj-core-features-highlight.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core-migrating-from-fest.html
+++ b/assertj-core-migrating-from-fest.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core-news.html
+++ b/assertj-core-news.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core-quick-start.html
+++ b/assertj-core-quick-start.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/assertj-core.html
+++ b/assertj-core.html
@@ -74,12 +74,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>

--- a/template-data/assertj-core-side-menu.html
+++ b/template-data/assertj-core-side-menu.html
@@ -15,12 +15,9 @@
                <li><a href="assertj-core.html#code">Code & issues <i class="fa fa-github"></i></a></li>
                <li><a href="assertj-core.html#contributing">Contributing</a></li>
                <li class="sidenav-header">Migrating</li>
-               <li><a href="assertj-core-migrating-from-fest.html">From Fest 2.x</a></li>
-               <li><a href="assertj-core-migrating-from-fest.html#fest-1.4">From Fest 1.4</a></li>
-               <li class="sidenav-header">Tools</li>
-               <li><a href="assertj-assertions-generator.html">Assertions generator</a></li>
-               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">Converting JUnit assertions to AssertJ</a></li>
-               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">Converting TestNG assertions to AssertJ</a></li>
+               <li><a href="assertj-core-converting-junit-assertions-to-assertj.html">From JUnit Assertions</a></li>
+               <li><a href="assertj-core-converting-testng-assertions-to-assertj.html">From TestNG Assertions</a></li>
+               <li><a href="assertj-core-migrating-from-fest.html">From Fest Assert</a></li>
             </ul>
          </div>
       </div>


### PR DESCRIPTION
…visible in right side menu" by
- Showing only a single fest section in the menu.
- Moving the converting sections to the migration section.
- Removing the tools section because the only thing left in was the assertion generator section and that is already in the top menu.

Feel free to close this if you prefer another solution.
