### PR TITLE
Add missing Neo4j space in libraries section

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ assertThat(fellowshipOfTheRing).filteredOn(character -> character.getName().cont
             <p>Check AssertJ Joda Time assertions <a href="assertj-joda-time.html#latest-release">latest news</a> and <a href="assertj-joda-time.html">documentation</a>.</p>
          </div>
          <div class="col-lg-4 col-md-4">
-            <h3><i class="fa fa-code"></i>Neo4J</h3>
+            <h3><i class="fa fa-code"></i> Neo4J</h3>
 
             <p>Provides assertions for Neo4J types like Node, Path and Relationship.</p>
 


### PR DESCRIPTION
This matches the space before Guava and JodaTime.