### PR TITLE
minimal correction of the 3.9.0 news section

### DIFF
--- a/assertj-core-news.html
+++ b/assertj-core-news.html
@@ -330,7 +330,7 @@ assertThat(Optional.empty()).get();</code></pre>
 <p>A variant of <span class="small-code">assertThatThrownBy</span> which accepts a description has been added.</p>
 <p>Example:</p>
 <pre><code class="java">// this assertion fails ... 
-assertThatThrownBy(() -> { throw new IOException("bam!"); }, "Test explosive code")
+assertThatThrownBy(() -> { throw new IOException("bam!"); }, "check explosion")
           .isInstanceOf(IOException.class)
           .hasMessageContaining("boom!");
 // ... with the following error message:

--- a/templates/assertj-core-news-template.html
+++ b/templates/assertj-core-news-template.html
@@ -260,7 +260,7 @@ assertThat(Optional.empty()).get();</code></pre>
 <p>A variant of <span class="small-code">assertThatThrownBy</span> which accepts a description has been added.</p>
 <p>Example:</p>
 <pre><code class="java">// this assertion fails ... 
-assertThatThrownBy(() -> { throw new IOException("bam!"); }, "Test explosive code")
+assertThatThrownBy(() -> { throw new IOException("bam!"); }, "check explosion")
           .isInstanceOf(IOException.class)
           .hasMessageContaining("boom!");
 // ... with the following error message:


### PR DESCRIPTION
```
assertThatThrownBy(() -> { throw new IOException("bam!"); }, "Test explosive code")
```
would actually give
```
java.lang.AssertionError: [Test explosive code] 
```