### PR TITLE
Add canonical links to new website

### DIFF
--- a/assertj-assertions-generator-maven-plugin.html
+++ b/assertj-assertions-generator-maven-plugin.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-assertions-generator.html
+++ b/assertj-assertions-generator.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-conditions.html
+++ b/assertj-core-conditions.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-converting-junit-assertions-to-assertj.html
+++ b/assertj-core-converting-junit-assertions-to-assertj.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-converting-junit5-assertions-to-assertj.html
+++ b/assertj-core-converting-junit5-assertions-to-assertj.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-converting-testng-assertions-to-assertj.html
+++ b/assertj-core-converting-testng-assertions-to-assertj.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-custom-assertions.html
+++ b/assertj-core-custom-assertions.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-features-highlight.html
+++ b/assertj-core-features-highlight.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-migrating-from-fest.html
+++ b/assertj-core-migrating-from-fest.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-news.html
+++ b/assertj-core-news.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-older-releases.html
+++ b/assertj-core-older-releases.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core-quick-start.html
+++ b/assertj-core-quick-start.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-core.html
+++ b/assertj-core.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-db-concepts.html
+++ b/assertj-db-concepts.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/#assertj-db" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-db-features-highlight.html
+++ b/assertj-db-features-highlight.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/#assertj-db" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-db-news.html
+++ b/assertj-db-news.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/#assertj-db" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-db.html
+++ b/assertj-db.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/#assertj-db" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-guava.html
+++ b/assertj-guava.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/#assertj-guava" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-help.html
+++ b/assertj-help.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-joda-time.html
+++ b/assertj-joda-time.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/#assertj-joda" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-neo4j.html
+++ b/assertj-neo4j.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-news.html
+++ b/assertj-news.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   <link rel="canonical" href="https://assertj.github.io/doc/" />
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-advanced.html
+++ b/assertj-swing-advanced.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-basics.html
+++ b/assertj-swing-basics.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-edt.html
+++ b/assertj-swing-edt.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-getting-started.html
+++ b/assertj-swing-getting-started.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-input.html
+++ b/assertj-swing-input.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-launch.html
+++ b/assertj-swing-launch.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-lookup.html
+++ b/assertj-swing-lookup.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-migrating.html
+++ b/assertj-swing-migrating.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-news.html
+++ b/assertj-swing-news.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-quick-start.html
+++ b/assertj-swing-quick-start.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-running.html
+++ b/assertj-swing-running.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-troubleshooting-lookups.html
+++ b/assertj-swing-troubleshooting-lookups.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-troubleshooting-screenshots.html
+++ b/assertj-swing-troubleshooting-screenshots.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing-troubleshooting.html
+++ b/assertj-swing-troubleshooting.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/assertj-swing.html
+++ b/assertj-swing.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/generate-html.py
+++ b/generate-html.py
@@ -31,6 +31,31 @@ template_data_map = {
     'assertj_assertions_generator_side_menu': content_of('assertj-assertions-generator-side-menu.html')
 }
 
+def new_doc_url_for_file(file_name):
+    if file_name.startswith("assertj-core") or file_name.startswith("assertj-news"):
+        return "https://assertj.github.io/doc/"
+    if file_name.startswith("assertj-db"):
+        return "https://assertj.github.io/doc/#assertj-db"
+    if file_name.startswith("assertj-guava"):
+        return "https://assertj.github.io/doc/#assertj-guava"
+    if file_name.startswith("assertj-joda-time"):
+        return "https://assertj.github.io/doc/#assertj-joda"
+    if file_name.startswith("assertj-neo4j"):
+        # TODO: Documentation for Neo4j is currently empty on new site
+        # return "https://assertj.github.io/doc/#assertj-neo4j"
+        return None
+    if file_name.startswith("assertj-swing"):
+        # TODO: Documentation on this old site here is more extensive; don't link to new one yet
+        # return "https://assertj.github.io/doc/#assertj-swing"
+        return None
+    if file_name.startswith("assertj-assertions-generator"):
+        # TODO: Documentation does not exist on new site yet
+        return None
+
+    # TODO: Only enable this once all documentation has been migrated to new site; see TODOs above
+    # return "https://assertj.github.io/doc/"
+    return None
+
 initial_dir = os.getcwd()
 templates_dir = "templates"
 os.chdir(templates_dir)
@@ -43,8 +68,15 @@ for template_file_name in glob.glob("*-template.html"):
     with open(template_file_path) as index_template_file:
         target_file_name_content = string.Template(index_template_file.read())
 
+    template_data_map_for_file = template_data_map.copy()
+    new_doc_url = new_doc_url_for_file(template_file_name)
+    # add canonical link to redirect search engines to new page, see
+    # https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+    canonical_link = "" if new_doc_url is None else f'<link rel="canonical" href="{new_doc_url}" />'
+    template_data_map_for_file["head"] = template_data_map_for_file["head"].replace("$canonical_link", canonical_link)
+
     # resolve template variables
-    target_file_name_content = target_file_name_content.safe_substitute(template_data_map)
+    target_file_name_content = target_file_name_content.safe_substitute(template_data_map_for_file)
 
     with open(target_file_name, "w") as target_file:
         target_file.write(target_file_name_content)

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/template-data/assertj-head.html
+++ b/template-data/assertj-head.html
@@ -6,6 +6,8 @@
 
    <title>AssertJ / Fluent assertions for java</title>
 
+   $canonical_link
+
    <!-- CSS -->
    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata|Source+Code+Pro|Open+Sans|Ubuntu|Varela+Round|Karla">
    <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/templates/assertj-db-concepts-template.html
+++ b/templates/assertj-db-concepts-template.html
@@ -14,6 +14,7 @@ $assertj_db_side_menu
 
    <div class="col-lg-10 col-md-10 col-sm-10 text-left" >
       <h1 class="page-header">AssertJ-DB concepts</h1>
+      <h2 style="color:darkblue;font-style: italic;"><u>AssertJ-DB site has moved to <a href="https://assertj.github.io/doc/#assertj-db">https://assertj.github.io/doc/</a></u></h2>
 
       <p>The purpose of this page is to show the different concepts specific to AssertJ-DB.</p>
 

--- a/templates/assertj-db-features-highlight-template.html
+++ b/templates/assertj-db-features-highlight-template.html
@@ -14,6 +14,7 @@ $assertj_db_side_menu
 
    <div class="col-lg-10 col-md-10 col-sm-10 text-left" >
       <h1 class="page-header">AssertJ-DB features highlight</h1>
+      <h2 style="color:darkblue;font-style: italic;"><u>AssertJ-DB site has moved to <a href="https://assertj.github.io/doc/#assertj-db">https://assertj.github.io/doc/</a></u></h2>
 
       <p>Before reading this page, it is recommended to be familiar with the <a href="assertj-db-concepts.html">concepts of AssertJ-DB</a>.</p>
 

--- a/templates/assertj-db-news-template.html
+++ b/templates/assertj-db-news-template.html
@@ -14,6 +14,7 @@ $menu
 
       <div class="col-lg-10 col-md-10 col-sm-10 text-left">
       <h1 class="page-header">AssertJ-DB latest news</h1>
+      <h2 style="color:darkblue;font-style: italic;"><u>AssertJ-DB site has moved to <a href="https://assertj.github.io/doc/#assertj-db">https://assertj.github.io/doc/</a></u></h2>
       <ul>
          <li><a href="#assertj-db-next">AssertJ-DB next release</a></li>
          <li><a href="#assertj-db-1.2.0">AssertJ-DB 1.3.0 release</a></li>

--- a/templates/assertj-db-template.html
+++ b/templates/assertj-db-template.html
@@ -14,6 +14,7 @@ $menu
 
       <div class="col-lg-10 col-md-10 col-sm-10 text-left">
          <h1 class="page-header">AssertJ-DB assertions</h1>
+         <h2 style="color:darkblue;font-style: italic;"><u>AssertJ-DB site has moved to <a href="https://assertj.github.io/doc/#assertj-db">https://assertj.github.io/doc/</a></u></h2>
 <img src="images/assertj-db_icon.png" height="60%" width="60%" />
          <p>AssertJ-DB provides assertions to test data in a database.
          It requires Java 7 or later and can be used with either JUnit or TestNG.


### PR DESCRIPTION
This hopefully makes search engines prefer the new site, see https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls

At least for me Google and Ecosia still return the old site as one of the first search results.

I have only added the canonical link to the pages which exist on the new site for now.

> [!NOTE]
> I am not that familiar with how canonical links work, whether using them here is the best approach and whether this might have undesired side effects. So feel free to reject this pull request if you don't think it is worth it.